### PR TITLE
Add globalized minor mode for quickfix.

### DIFF
--- a/quickfix-mode.el
+++ b/quickfix-mode.el
@@ -121,4 +121,4 @@
 
 
 (provide 'quickfix-mode)
-;;; quickfix-python.el ends here
+;;; quickfix-mode.el ends here


### PR DESCRIPTION
With this patch quickfix can be now activated as a globalized minor mode like this:

```
(quickfix-global-mode 1)
```

What it does is that after you open a file, if the current file is elegible to have flymake syntax check activated then it will auto-activate quickfix-mode too.
