### PR TITLE
Allow to register handlers per mode.

### DIFF
--- a/quickfix-erlang.el
+++ b/quickfix-erlang.el
@@ -75,9 +75,9 @@
 
 ;; registering handlers
 (quickfix-add-handler quickfix-erlang-undefined-fn-predicate
-                      'quickfix-erlang-undefined-fn-handler)
+                      'quickfix-erlang-undefined-fn-handler
+                      'erlang-mode)
 
 (quickfix-add-handler quickfix-erlang-unused-fn-predicate
-                      'quickfix-erlang-unused-fn-handler)
-
-(add-to-list 'quickfix-modes 'erlang-mode)
+                      'quickfix-erlang-unused-fn-handler
+                      'erlang-mode)


### PR DESCRIPTION
This patch adds to quickfix-add-handler the ability to register
handlers for particular major-modes only.  This supersedes the
`quickfix-modes' feature as a way to ensure the mode should have
quickfix enabled.

Vars:
- quickfix-modes: Remove.
- quickfix-mode-handlers: Is now an association list where the key
  is the major mode and values are handlers.  This is true except for
  the t key which holds all global handlers.

Functions:
- quickfix-major-mode-is-registered: Remove.
- quickfix-add-handler: Receives a third optional argument called
  MODES. It can be a symbol or list of symbol for modes the handler
  should be enabled. If MODES is nil the handler is registered as a
  global one.
- quickfix-get-handlers: Use new data structure.
