### PR TITLE
New style handlers

### DIFF
--- a/quickfix-erlang.el
+++ b/quickfix-erlang.el
@@ -38,7 +38,7 @@
   (if (<= n 0) (mapconcat 'identity acc ",")
     (quickfix-erlang-generic-arguments- (- n 1) (cons (format "_Arg%d" n) acc))))
 
-(defun quickfix-erlang-undefined-fn-handler (issue-at-point)
+(defun quickfix-erlang-undefined-fn-fix (issue-at-point)
   (interactive)
   (let* ((name-and-arity (quickfix-erlang-get-undefined-function-name-and-arity issue-at-point))
          (fn-name (car name-and-arity))
@@ -57,7 +57,7 @@
     (beginning-of-line)
     (search-forward "(")))
 
-(defun quickfix-erlang-unused-fn-handler (issue-at-point)
+(defun quickfix-erlang-unused-fn-fix (issue-at-point)
   (save-excursion
     (interactive)
     (let* ((name-and-arity (quickfix-erlang-get-undefined-function-name-and-arity issue-at-point))
@@ -80,12 +80,19 @@
 
 
 ;; registering handlers
-(quickfix-add-handler quickfix-erlang-undefined-fn-predicate
-                      'quickfix-erlang-undefined-fn-handler
-                      'erlang-mode)
 
-(quickfix-add-handler quickfix-erlang-unused-fn-predicate
-                      'quickfix-erlang-unused-fn-handler
-                      'erlang-mode)
+(defvar quickfix-erlang-undefined-fn-handler
+  (quickfix-make-handler quickfix-erlang-undefined-fn-predicate
+                         'quickfix-erlang-undefined-fn-fix))
+
+(defvar quickfix-erlang-unused-fn-handler
+  (quickfix-make-handler quickfix-erlang-unused-fn-predicate
+                         'quickfix-erlang-unused-fn-fix))
+
+(quickfix-add-handler
+ quickfix-erlang-undefined-fn-handler 'erlang-mode)
+
+(quickfix-add-handler
+ quickfix-erlang-unused-fn-handler 'erlang-mode)
 
 ;;; quickfix-erlang.el ends here

--- a/quickfix-python.el
+++ b/quickfix-python.el
@@ -23,8 +23,8 @@
    "Indent with spaces only."))
 
 (quickfix-add-handler
- quickfix-python-mixed-tabs-and-spaces-predicate
- 'quickfix-python-mixed-tabs-and-spaces
+ (quickfix-make-handler quickfix-python-mixed-tabs-and-spaces-predicate
+                        'quickfix-python-mixed-tabs-and-spaces)
  'python-mode)
 
 
@@ -38,8 +38,8 @@
    "Jump to 79th char."))
 
 (quickfix-add-handler
- quickfix-python-line-too-long-predicate
- 'quickfix-python-line-too-long
+ (quickfix-make-handler quickfix-python-line-too-long-predicate
+                        'quickfix-python-line-too-long)
  'python-mode)
 
 
@@ -53,8 +53,8 @@
    "Delete trailing whitespace."))
 
 (quickfix-add-handler
- quickfix-python-trailing-whitespace-predicate
- 'quickfix-python-trailing-whitespace
+ (quickfix-make-handler quickfix-python-trailing-whitespace-predicate
+                        'quickfix-python-trailing-whitespace)
  'python-mode)
 
 
@@ -83,8 +83,8 @@
        (format "Add %s newline%s." num-lines (if (> num-lines 1) "s" ""))))))
 
 (quickfix-add-handler
- quickfix-python-expected-newlines-predicate
- 'quickfix-python-expected-newlines
+ (quickfix-make-handler quickfix-python-expected-newlines-predicate
+                        'quickfix-python-expected-newlines)
  'python-mode)
 
 
@@ -113,8 +113,8 @@
        (format "Remove %s newline%s." num-lines (if (> num-lines 1) "s" ""))))))
 
 (quickfix-add-handler
- quickfix-python-too-many-newlines-predicate
- 'quickfix-python-too-many-newlines
+ (quickfix-make-handler quickfix-python-too-many-newlines-predicate
+                        'quickfix-python-too-many-newlines)
  'python-mode)
 
 
@@ -137,8 +137,8 @@
    "Replace backticks with repr()"))
 
 (quickfix-add-handler
- quickfix-python-backticks-predicate
- 'quickfix-python-backticks
+ (quickfix-make-handler quickfix-python-backticks-predicate
+                        'quickfix-python-backticks)
  'python-mode)
 
 
@@ -160,8 +160,8 @@
    "Replace <> with !="))
 
 (quickfix-add-handler
- quickfix-python-not-equal-comparison-predicate
- 'quickfix-python-not-equal-comparison
+ (quickfix-make-handler quickfix-python-not-equal-comparison-predicate
+                        'quickfix-python-not-equal-comparison)
  'python-mode)
 
 


### PR DESCRIPTION
New style handlers. Now quickfix-handlers are menu items which return the appropriate action on selection. The menu list is still built based upon predicates which return the description of the fix.
